### PR TITLE
✨ 修复 Vue 变更默认版本造成的问题，并引入新示例

### DIFF
--- a/src/vditor/demo/vue.html
+++ b/src/vditor/demo/vue.html
@@ -34,7 +34,7 @@
     <meta name="twitter:site" content="@b3logos"/>
     <meta name="twitter:creator" content="@b3logos"/>
     <script src="https://b3log.org/vditor/vditor.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/vue" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"></script>
     <style>
         .header {
             background-color: #fff;
@@ -84,6 +84,14 @@
 })
 </code></pre>
     </div>
+    <div class="fn-50"></div>
+    <h2>Vue 3 组合式 API + TypeScript</h2>
+    <iframe src="https://codesandbox.io/embed/vue3-vditor-minimal-example-8mkvqy?fontsize=14&hidenavigation=1&module=%2Fsrc%2FApp.vue&theme=dark"
+     style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+     title="Vue3-Vditor-Minimal-Example"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+   ></iframe>
     <div class="fn-100"></div>
     <div class="fn-clear">
         <h2 class="fn-left">参与讨论</h2>

--- a/src/vditor/demo/vue.html
+++ b/src/vditor/demo/vue.html
@@ -34,7 +34,7 @@
     <meta name="twitter:site" content="@b3logos"/>
     <meta name="twitter:creator" content="@b3logos"/>
     <script src="https://b3log.org/vditor/vditor.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js" defer></script>
     <style>
         .header {
             background-color: #fff;


### PR DESCRIPTION
1. Vue 将默认版本变更为 3，这使得原有示例失效了。我指定 Vue 的版本号，修复了这个问题。
2. 与此同时，我加入了使用 Vue 3 和现代前端开发方式的新示例。

不建议像之前的 React 示例一样把旧示例删除，Vue 2 仍然存在相当大的用户基数，旧示例因此依然具有意义。