### PR TITLE
Improve HarmonyOS Logo image stretching

### DIFF
--- a/src/siyuan/src/download.pug
+++ b/src/siyuan/src/download.pug
@@ -102,7 +102,7 @@ block content
                 a(class="download__link" href="https://testflight.apple.com/join/BBLHMJ4g" target="_blank" rel="nofollow") TestFlight
                 a(class="download__link" href="https://github.com/siyuan-note/siyuan-ios" target="_blank") 源代码
             div(class="item")
-                img(src="https://b3log.org/siyuan/static/logo-harmonyos.png" style="width: 240px;")
+                img(src="https://b3log.org/siyuan/static/logo-harmonyos.png")
                 h3 鸿蒙 NEXT
                 span(style="margin-bottom:0")
                     | 已上架应用市场&nbsp;&nbsp

--- a/src/siyuan/static/base.css
+++ b/src/siyuan/static/base.css
@@ -646,7 +646,8 @@ kbd {
 
 .download .item img {
     height: 64px;
-    width: 64px;
+    width: max-content;
+    object-fit: contain;
     margin-bottom: 18px;
 }
 


### PR DESCRIPTION
改进前：

<img width="478" height="475" alt="image" src="https://github.com/user-attachments/assets/ad410bd9-1ca1-4566-bebc-73ff591e36f1" />

改进后：

<img width="479" height="493" alt="image" src="https://github.com/user-attachments/assets/60dbc3a8-59a8-4ee6-8384-cd239b8b3d94" />
